### PR TITLE
refactor: Changed GetLinkingLink action name to include 'Action'.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.mymetaverse.sdk</groupId>
     <artifactId>java-sdk</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/src/main/java/io/mymetavese/metaapi/api/actions/GetLinkingLinkAction.java
+++ b/src/main/java/io/mymetavese/metaapi/api/actions/GetLinkingLinkAction.java
@@ -3,5 +3,5 @@ package io.mymetavese.metaapi.api.actions;
 import io.mymetavese.metaapi.api.RestAction;
 import io.mymetavese.metaapi.api.entities.LinkingLink;
 
-public interface GetLinkingLink extends RestAction<LinkingLink> {
+public interface GetLinkingLinkAction extends RestAction<LinkingLink> {
 }

--- a/src/main/java/io/mymetavese/metaapi/api/entities/v2/GameEntity.java
+++ b/src/main/java/io/mymetavese/metaapi/api/entities/v2/GameEntity.java
@@ -59,7 +59,7 @@ public interface GameEntity extends ApiEntity {
      *
      * @return An action that represents the linking link.
      */
-    GetLinkingLink getLinkingLink();
+    GetLinkingLinkAction getLinkingLink();
 
     /**
      * Get the currently active metacitizen for this game entity.

--- a/src/main/java/io/mymetavese/metaapi/requests/actions/GetLinkingLinkActionImpl.java
+++ b/src/main/java/io/mymetavese/metaapi/requests/actions/GetLinkingLinkActionImpl.java
@@ -1,14 +1,14 @@
 package io.mymetavese.metaapi.requests.actions;
 
 import io.mymetavese.metaapi.api.MetaAPI;
-import io.mymetavese.metaapi.api.actions.GetLinkingLink;
+import io.mymetavese.metaapi.api.actions.GetLinkingLinkAction;
 import io.mymetavese.metaapi.api.entities.v2.GameEntity;
 import io.mymetavese.metaapi.api.entities.LinkingLink;
 import io.mymetavese.metaapi.requests.RestActionImpl;
 import io.mymetavese.metaapi.requests.entities.LinkingLinkImpl;
 import io.mymetavese.metaapi.requests.routes.Routes;
 
-public class GetLinkingLinkActionImpl extends RestActionImpl<LinkingLink> implements GetLinkingLink {
+public class GetLinkingLinkActionImpl extends RestActionImpl<LinkingLink> implements GetLinkingLinkAction {
 
     private final GameEntity gameEntity;
 

--- a/src/main/java/io/mymetavese/metaapi/requests/actions/drops/ConsumeDropActionImpl.java
+++ b/src/main/java/io/mymetavese/metaapi/requests/actions/drops/ConsumeDropActionImpl.java
@@ -1,6 +1,5 @@
 package io.mymetavese.metaapi.requests.actions.drops;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import io.mymetavese.metaapi.api.MetaAPI;
 import io.mymetavese.metaapi.api.actions.drops.ConsumeDropAction;
@@ -11,12 +10,8 @@ import io.mymetavese.metaapi.requests.JsonObject;
 import io.mymetavese.metaapi.requests.RestActionImpl;
 import io.mymetavese.metaapi.requests.entities.drops.responses.DropConsumedResponseImpl;
 import io.mymetavese.metaapi.requests.routes.Routes;
-import okhttp3.Response;
 
-import java.io.IOException;
-import java.io.Reader;
 import java.util.List;
-import java.util.Objects;
 
 public class ConsumeDropActionImpl extends RestActionImpl<DropConsumedResponse> implements ConsumeDropAction {
 
@@ -29,24 +24,6 @@ public class ConsumeDropActionImpl extends RestActionImpl<DropConsumedResponse> 
         this.dropId = dropId;
         this.dropReceiver = dropReceiver;
         this.dropEntryRequirements = dropEntryRequirements;
-    }
-
-    @Override
-    public DropConsumedResponse transform(Response response) {
-
-        if (response == null || response.body() == null) {
-            throw new NullPointerException("Response cannot be null");
-        }
-
-        Gson gson = new Gson();
-        try (Reader reader = Objects.requireNonNull(response.body()).charStream()) {
-            return gson.fromJson(reader, DropConsumedResponseImpl.class);
-        } catch (IOException ex) {
-            ex.printStackTrace();
-        }
-
-        return null;
-
     }
 
     @Override

--- a/src/main/java/io/mymetavese/metaapi/requests/entities/GameEntityImpl.java
+++ b/src/main/java/io/mymetavese/metaapi/requests/entities/GameEntityImpl.java
@@ -56,7 +56,7 @@ public class GameEntityImpl implements GameEntity {
     }
 
     @Override
-    public GetLinkingLink getLinkingLink() {
+    public GetLinkingLinkAction getLinkingLink() {
         return new GetLinkingLinkActionImpl(metaAPI, this);
     }
 


### PR DESCRIPTION
### Description:

To follow the pattern, all Java classes that represent Actions should have the suffix 'Action'. Changed the name of the GetLinkingLink in order to follow this pattern.