### PR TITLE
fix: Dead Lock on Synchronous Action call.

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.mymetaverse.sdk</groupId>
   <artifactId>java-sdk</artifactId>
-  <version>2.5.0</version>
+  <version>2.5.2</version>
   <build>
     <defaultGoal>package install</defaultGoal>
     <finalName>${project.name}-${project.version}</finalName>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.mymetaverse.sdk</groupId>
     <artifactId>java-sdk</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.2</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/src/main/java/io/mymetavese/metaapi/api/RestAction.java
+++ b/src/main/java/io/mymetavese/metaapi/api/RestAction.java
@@ -3,7 +3,9 @@ package io.mymetavese.metaapi.api;
 import io.mymetavese.metaapi.MetaAPIImpl;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 public interface RestAction<T> {
@@ -23,7 +25,6 @@ public interface RestAction<T> {
     /**
      * Submits a request for execution in asynchronous logic.
      *
-     *
      * @param success The success callback from the request.
      * @param failure The callback error from the request.
      */
@@ -31,7 +32,6 @@ public interface RestAction<T> {
 
     /**
      * Submits a request for execution in asynchronous logic.
-     *
      *
      * @param success The success callback from the request.
      */
@@ -45,6 +45,13 @@ public interface RestAction<T> {
      * @return The response of the Request.
      */
     T complete();
+
+    /**
+     * Submits a Request in synchronous logic with a Timeout
+     *
+     * @return The response of the Request.
+     */
+    T complete(long timeout, TimeUnit timeUnit) throws ExecutionException, InterruptedException, TimeoutException;
 
     /**
      * Submits a request for execution after some time delay.

--- a/src/main/java/io/mymetavese/metaapi/requests/RestActionImpl.java
+++ b/src/main/java/io/mymetavese/metaapi/requests/RestActionImpl.java
@@ -15,6 +15,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 public abstract class RestActionImpl<T> extends Transformable<T> implements RestAction<T> {
@@ -104,5 +107,11 @@ public abstract class RestActionImpl<T> extends Transformable<T> implements Rest
     public T complete() {
         return submit().join();
     }
+
+    @Override
+    public T complete(long timeout, TimeUnit timeUnit) throws ExecutionException, InterruptedException, TimeoutException {
+        return submit().get(timeout, timeUnit);
+    }
+
 }
 


### PR DESCRIPTION
### Description:

When calling an action asynchronously, if the result were an `Internal Server Error (500)`, the code would be blocked as the Response would never be processed. This PR fixes that. 

This PR also introduces a way to set a timeout for Synchronous Action calls. 